### PR TITLE
Adiciona actions de deploy

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,49 @@
+name: Deploy production
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy-ecr:
+    env:
+      IMAGE_TAG: latest
+      APP_MODE: release
+      IMAGE_REPOSITORY_NAME: ${{ github.repository }}
+      STAGING_FUNCTION_NAME: ${{ secrets.PRODUCTION_FUNCTION_NAME }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }} 
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push the image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/$IMAGE_REPOSITORY_NAME:$IMAGE_TAG -f ./build/docker/Dockerfile --build-arg APP_MODE=$APP_MODE --no-cache .
+          docker push $ECR_REGISTRY/$IMAGE_REPOSITORY_NAME:$IMAGE_TAG
+
+      - name: Update Lambda
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          aws lambda update-function-code \
+              --function-name $PRODUCTION_FUNCTION_NAME \
+              --image-uri $ECR_REGISTRY/$IMAGE_REPOSITORY_NAME:$IMAGE_TAG


### PR DESCRIPTION
## Impacto

Este PR adiciona o workflow a ser usado para fazer deploy em produção da API utilizando o registry do projeto no Amazon ECR, e atualização da lambda function usando a imagem publicada. A implementação é a mesma usada para staging. Porém, algumas coisas foram alteradas:

- Action: `Deploy production`
- On push branch: `main`
- Tag da imagem de produção: `latest` (mais tarde podemos criar labels de versão das releases)
- variável de ambiente `APP_MODE=release`, não terá logs do tipo `debug` no [cloudwatch](https://sa-east-1.console.aws.amazon.com/cloudwatch/home?region=sa-east-1#home:dashboards/Lambda)
- criação da secret `PRODUCTION_FUNCTION_NAME` com o nome da lambda de produção

**OBS: A função lambda por enquanto está utilizando a imagem de staging, mas quando este PR for mergido, irá automaticamente publicar uma imagem production e apontar para ela**

## Link da task

[Notion](https://www.notion.so/habitsTodo-Backend-Configurar-estrutura-de-pipeline-de-build-production-latest-c2b600340e3345bdb53ba7dcd0cfe946?pvs=4)