### PR TITLE
Docs: Setup do projeto com execução da API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,40 @@ Este repositório contém o back-end com todas funcionalidades (API first) do pr
   - KMM (Kotlin Multiplatform Mobile): Android and IOS 
 
 ## Setup
-Para criar o .env e arquivos usados nos volumes dos containers docker:
+
+### Dependências
+- [Go](https://go.dev/) (v1.23.0 ou superior) - Linguagem de programação de código aberto que facilita a construção de software simples, confiável e eficiente.
+- [Docker](https://www.docker.com/) - Plataforma para desenvolvimento, envio e execução de aplicativos em contêineres.
+- [Docker Compose](https://docs.docker.com/compose/) - Ferramenta para definir e executar aplicativos Docker com múltiplos contêineres usando um arquivo YAML.
+
+
+### Executando o projeto
+
+1. Para criar o .env e arquivos usados nos volumes dos containers docker:
 ```
 make setup
 ```
 
-### Dependências
-- [Go](https://go.dev/) - Linguagem de programação de código aberto que facilita a construção de software simples, confiável e eficiente.
-- [Docker](https://www.docker.com/) - Plataforma para desenvolvimento, envio e execução de aplicativos em contêineres.
-- [Docker Compose](https://docs.docker.com/compose/) - Ferramenta para definir e executar aplicativos Docker com múltiplos contêineres usando um arquivo YAML.
+> Realize eventuais ajustes nas portas do `.env` caso alguma porta já esteja ocupada em seu ambiente local.
 
-### Instalação
-Para subir o container docker:
+2. Para subir o container docker:
 ```
 docker compose up
 ```
+
+3. Para resolver as dependências, na raiz do projeto, execute:
+
+```
+go mod tidy
+```
+
+4. Para iniciar o projeto, execute: 
+
+```
+go run cmd/habits-todo-backend/main.go
+```
+
+A mensagem de log `[GIN-debug] Listening and serving HTTP on :<porta>` deve aparecer e será possível acessar a rota `localhost:<porta>/api/health` para o health check.
 
 ## Como contribuir
 ...


### PR DESCRIPTION
### Impacto

Esta PR adiciona a documentação para setup considerando a execução da API em go, que não estava na documentação anterior.

### Link da tarefa

[Notion](https://www.notion.so/HabitsTodo-Backend-Documentar-no-README-o-setup-do-projeto-com-o-GO-159059f0e43e80a4a000d04de63e42c2?pvs=4)