### PR TITLE
Refatorando registro de rotas para receberem os controllers via argumento

### DIFF
--- a/internal/api/route/google_auth_routes.go
+++ b/internal/api/route/google_auth_routes.go
@@ -5,9 +5,7 @@ import (
 	"github.com/scienceandcode/habits-todo-backend/internal/api/controller"
 )
 
-func GoogleAuthRoutes(group *gin.RouterGroup) {
-	controller := &controller.GoogleAuthController{}
-
+func GoogleAuthRoutes(controller *controller.GoogleAuthController, group *gin.RouterGroup) {
 	group.GET("/setup", controller.StartGoogleAuthorization)
 	group.GET("/code", controller.AuthorizationCode)
 }

--- a/internal/api/route/health_routes.go
+++ b/internal/api/route/health_routes.go
@@ -5,8 +5,6 @@ import (
 	"github.com/scienceandcode/habits-todo-backend/internal/api/controller"
 )
 
-func HealthRoutes(group *gin.RouterGroup) {
-	controller := &controller.HealthController{}
-
+func HealthRoutes(controller *controller.HealthController, group *gin.RouterGroup) {
 	group.GET("/health", controller.GetHealth)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,8 +15,8 @@ type HttpServer struct {
 func (httpServer *HttpServer) registerRoutes(app *gin.Engine) {
 	rootGroup := app.Group("/api")
 
-	route.HealthRoutes(rootGroup)
-	route.GoogleAuthRoutes(rootGroup.Group("/google/auth"))
+	route.HealthRoutes(httpServer.healthController, rootGroup)
+	route.GoogleAuthRoutes(httpServer.googleAuthController, rootGroup.Group("/google/auth"))
 }
 
 func (httpServer *HttpServer) Run() {


### PR DESCRIPTION
### Impacto

Identifiquei que o registro de rotas estava referenciando os controllers em variáveis internas das funções para posteriormente registrar as rotas nos métodos dos controllers. No entanto, o httpServer já recebe via injeção esses controllers para fornecê-los para as rotas. Este PR faz esta refatoração para que as rotas sigam o padrão de receber suas dependências via argumento nas funções de registro.

### Task

[Notion](https://www.notion.so/HabitsTodo-Backend-Receber-inst-ncias-dos-controllers-no-registro-de-rotas-inje-o-de-depend-ncia-172059f0e43e80d3a384ec2671d91de4?pvs=4)

### Cenários testados

- Start da aplicação com as refatorações aplicadas
- Chamada da rota health check para verificar o funcionamento do roteamento