### PR TITLE
Remove seções Inutilizadas do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,3 @@ go run cmd/habits-todo-backend/main.go
 ```
 
 A mensagem de log `[GIN-debug] Listening and serving HTTP on :<porta>` deve aparecer e será possível acessar a rota `localhost:<porta>/api/health` para o health check.
-
-## Como contribuir
-...
-
-## Histórico do projeto
-...


### PR DESCRIPTION
### Impacto

Com a criação da pagina da wiki [HabitsToDocs](https://github.com/scienceandcode/habits-todo-backend/wiki/HabitsToDocs), as seções "Como contribuir" e "Histórico do projeto" nao são mais necessárias de ficar no README do projeto.

### Task

[Notion](https://www.notion.so/HabitsTodo-backend-docs-remover-se-es-inutilizadas-do-README-173059f0e43e80418391e38073c1ac2c?pvs=4)