### PR TITLE
Referencia conteúdos novos da wiki no README do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Este repositório contém o back-end com todas funcionalidades (API first) do pr
     - AWS lambda (infraestrutura)
   - CockroachDB (postgres)
 - Front-end:
-  - KMM (Kotlin Multiplatform Mobile): Android and IOS 
+  - KMM (Kotlin Multiplatform Mobile): Android and IOS
+ 
+Para maiores informações sobre a estrutura e documentações do projeto, consulte a [Wiki](https://github.com/scienceandcode/habits-todo-backend/wiki).
 
 ## Setup
 


### PR DESCRIPTION
### Impacto

Com a escrita da [nova wiki](https://github.com/scienceandcode/habits-todo-backend/wiki), é necessário indicar na landing page do nosso projeto que os conteúdos mais completos e aprofundados podem ser encontrados nela.

### Task

[Notion](https://www.notion.so/HabitsTodo-Backend-docs-Referenciar-wiki-do-projeto-no-README-para-facilitar-o-acesso-173059f0e43e80039c22f48622c626e8?pvs=4)