### PR TITLE
[FIX] Adjusts jwt service to handle user id as uint

### DIFF
--- a/internal/api/service/jwt_service.go
+++ b/internal/api/service/jwt_service.go
@@ -11,7 +11,7 @@ type JWTService struct {
 	SecretKey string
 }
 
-func (j *JWTService) GenerateJWT(userID int) (string, error) {
+func (j *JWTService) GenerateJWT(userID uint) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"user_id": userID,
 		"exp":     time.Now().Add(time.Hour * 24).Unix(),
@@ -20,7 +20,7 @@ func (j *JWTService) GenerateJWT(userID int) (string, error) {
 	return token.SignedString([]byte(j.SecretKey))
 }
 
-func (j *JWTService) ValidateJWT(tokenString string) (int, error) {
+func (j *JWTService) ValidateJWT(tokenString string) (uint, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, errors.New("unexpected signing method")
@@ -37,7 +37,7 @@ func (j *JWTService) ValidateJWT(tokenString string) (int, error) {
 		if !ok {
 			return 0, errors.New("invalid user_id in token")
 		}
-		return int(userID), nil
+		return uint(userID), nil
 	}
 
 	return 0, errors.New("invalid token")

--- a/internal/api/service/user_auth_service.go
+++ b/internal/api/service/user_auth_service.go
@@ -46,7 +46,7 @@ func (service *UserAuthService) Login(loginRequestDTO *dto.LoginRequestDTO) (*dt
 	}
 
 	jwtService := NewJWTService(common.GetEnv("JWT_SECRET_KEY"))
-	token, err := jwtService.GenerateJWT(int(user.ID))
+	token, err := jwtService.GenerateJWT(user.ID)
 
 	if err != nil {
 		return nil, errors.NewError("Error generating token.", nil)

--- a/internal/api/service/user_service.go
+++ b/internal/api/service/user_service.go
@@ -16,7 +16,7 @@ func (service *UserService) Profile(c *gin.Context) (*dto.UserDTO, *errors.Error
 		return nil, errors.NewError("User ID not found in context", nil)
 	}
 
-	id, ok := userID.(int)
+	id, ok := userID.(uint)
 	if !ok {
 		return nil, errors.NewError("Invalid user ID type in context", nil)
 	}


### PR DESCRIPTION
### Impacto

Atualmente a implementação de JWT trata o id de usuário como int ao invés de uint. Em staging deu problema porque os IDS do banco de dados são muito extensos e são uint64. No local não pegamos por não ter ids extensos. 

Esta PR tem o objetivo de corrigir esse comportamento.

### Cenários testados

- Geração do token
- Envio de token válido na rota profile
- Envio de token invaido na rota profile