### PR TITLE
fix: generate JWT claims with userID as string

### DIFF
--- a/internal/api/service/jwt_service.go
+++ b/internal/api/service/jwt_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt"
@@ -13,7 +14,7 @@ type JWTService struct {
 
 func (j *JWTService) GenerateJWT(userID uint) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": userID,
+		"user_id": strconv.FormatUint(uint64(userID), 10),
 		"exp":     time.Now().Add(time.Hour * 24).Unix(),
 	})
 
@@ -33,11 +34,13 @@ func (j *JWTService) ValidateJWT(tokenString string) (uint, error) {
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-		userID, ok := claims["user_id"].(float64)
+		userID, ok := claims["user_id"]
 		if !ok {
 			return 0, errors.New("invalid user_id in token")
 		}
-		return uint(userID), nil
+
+		parsedUserID, _ := strconv.ParseUint(userID.(string), 10, 64)
+		return uint(parsedUserID), nil
 	}
 
 	return 0, errors.New("invalid token")


### PR DESCRIPTION
### Impacto

A PR https://github.com/scienceandcode/habits-todo-backend/pull/17 não solucionou o problema de converter corretamente o id do user na autenticação do token JWT. Por algum motivo, ao validar o token, as claims automaticamente convertiam o id do user para float64 na hora de verificar se o token era válido, mesmo que tenhamos gerado o token passando o userID com uint. Esse comportamento causava uma diferença no id porque float64 e uint são de tamanhos suportados diferentes. 

Nesta PR, implementei uma alteração para que a gente sempre gere o token JWT passando o userID convertido para string, e posteriormente quando o token vai ser validado, a verificação é feita como string. Desta forma o valor que foi usado para geração do token é retornada corretamente (não perdemos nenhum caractere pois a string é preservada, diferente do uint que automaticamente virava float64), e quando retornamos o id do usuário para salvar no contexto, convertemos ele novamente para uint, garantindo a consistência do tipo no context da request.

Para garantir o sucesso da implementação, simulei um ID de 19 casas (mesmo tamanho de id que quebrou em staging) que é convertido para uint64 em runtime, e obtive sucesso na obtenção do profile (pois a query conseguiu passar o id correto). Conforme print abaixo:

![image](https://github.com/user-attachments/assets/7ddf36ae-6e6b-4da4-bbf1-27db6b9942d5)
