### PR TITLE
Validar os escopos de autorização necessários da conta google

### DIFF
--- a/internal/api/service/google_auth_service.go
+++ b/internal/api/service/google_auth_service.go
@@ -69,11 +69,50 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("response", "Invalid auth response body")})
 	}
 
+	tokenValidationError := service.validateTokenResponseDTO(tokenResponseDTO)
+
+	if tokenValidationError != nil {
+		return tokenValidationError
+	}
+
 	err = service.saveToken(tokenResponseDTO)
 
 	if err != nil {
 		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
 		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("token", "Error while saving token")})
+	}
+
+	return nil
+}
+
+func (service *GoogleAuthService) validateTokenResponseDTO(tokenResponseDTO *integration.GoogleOAuthTokenResponseDTO) *errors.Error {
+	dataValidationErrors := []*errors.FieldError{}
+
+	scopeError := service.validateTokenScope(tokenResponseDTO.Scope)
+
+	if scopeError != nil {
+		dataValidationErrors = append(dataValidationErrors, scopeError)
+	}
+
+	if len(dataValidationErrors) > 0 {
+		return errors.NewError("Error while authenticating your google account", dataValidationErrors)
+	}
+
+	return nil
+}
+
+func (*GoogleAuthService) validateTokenScope(scopeStr string) *errors.FieldError {
+	granularRequiredScope := []string{
+		"https://www.googleapis.com/auth/calendar",
+		"https://www.googleapis.com/auth/userinfo.email",
+		"https://www.googleapis.com/auth/userinfo.profile",
+		"openid",
+	}
+
+	for _, scope := range granularRequiredScope {
+		if !strings.Contains(scopeStr, scope) {
+			return errors.NewFieldError("scope", "You need to grant all required permissions to use HabitsTodo with your Google Calendar.")
+		}
 	}
 
 	return nil

--- a/internal/api/service/google_auth_service.go
+++ b/internal/api/service/google_auth_service.go
@@ -66,7 +66,7 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 
 	if err != nil {
 		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("response", "Auth Request Failed")})
+		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("response", "Auth request failed.")})
 	}
 
 	tokenValidationError := service.validateTokenResponseDTO(tokenResponseDTO)
@@ -95,7 +95,7 @@ func (service *GoogleAuthService) validateTokenResponseDTO(tokenResponseDTO *int
 	}
 
 	if len(dataValidationErrors) > 0 {
-		return errors.NewError("Error while authenticating your google account", dataValidationErrors)
+		return errors.NewError("Error while authenticating your google account.", dataValidationErrors)
 	}
 
 	return nil
@@ -130,7 +130,7 @@ func (*GoogleAuthService) validateCodeAndState(code, state string) *errors.Error
 	}
 
 	if len(dataValidationErrors) > 0 {
-		return errors.NewError("Invalid request data", dataValidationErrors)
+		return errors.NewError("Invalid request data.", dataValidationErrors)
 	}
 
 	return nil

--- a/internal/api/service/google_auth_service.go
+++ b/internal/api/service/google_auth_service.go
@@ -39,10 +39,10 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 	}
 
 	decryptedState, _ := common.DecryptAES(state)
-	defaultErrorMessage := "Error while exchanging code for token"
+	defaultErrorMessage := "Error while authenticating your Google account."
 
 	if common.GetEnv("GOOGLE_CLOUD_AUTH_STATE_SECRET_KEY") != decryptedState {
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("state", "Invalid state")})
+		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("state", "Invalid origin state.")})
 	}
 
 	httpClient := &http.Client{}
@@ -50,7 +50,7 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 
 	if err != nil {
 		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed")})
+		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed.")})
 	}
 
 	defer res.Body.Close()
@@ -58,7 +58,7 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
 		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, string(body)))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed")})
+		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed.")})
 	}
 
 	tokenResponseDTO := integration.NewGoogleOAuthTokenResponseDTO()
@@ -66,7 +66,7 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 
 	if err != nil {
 		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("response", "Invalid auth response body")})
+		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("response", "Auth Request Failed")})
 	}
 
 	tokenValidationError := service.validateTokenResponseDTO(tokenResponseDTO)
@@ -79,7 +79,7 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 
 	if err != nil {
 		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("token", "Error while saving token")})
+		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("token", "Error while saving your credentials.")})
 	}
 
 	return nil

--- a/internal/api/service/google_auth_service.go
+++ b/internal/api/service/google_auth_service.go
@@ -19,6 +19,8 @@ import (
 
 type GoogleAuthService struct{}
 
+const DEFAULT_ERROR_MESSAGE = "Error while authenticating your google account. Please try again."
+
 func (*GoogleAuthService) BuildGoogleAuthURL() string {
 	clientId := common.GetEnv("GOOGLE_CLOUD_CLIENT_ID")
 	redirectUri := common.GetEnv("GOOGLE_CLOUD_REDIRECT_URI")
@@ -39,34 +41,33 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 	}
 
 	decryptedState, _ := common.DecryptAES(state)
-	defaultErrorMessage := "Error while authenticating your Google account. Please try again."
 
 	if common.GetEnv("GOOGLE_CLOUD_AUTH_STATE_SECRET_KEY") != decryptedState {
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("state", "Invalid origin state.")})
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, []*errors.FieldError{errors.NewFieldError("state", "Invalid origin state.")})
 	}
 
 	httpClient := &http.Client{}
 	res, err := httpClient.Post("https://oauth2.googleapis.com/token", "application/x-www-form-urlencoded", strings.NewReader(service.buildTokenRequestFormData(code).Encode()))
 
 	if err != nil {
-		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed.")})
+		logger.Error(fmt.Sprintf("%s: %s", DEFAULT_ERROR_MESSAGE, err.Error()))
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed.")})
 	}
 
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, string(body)))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed.")})
+		logger.Error(fmt.Sprintf("%s: %s", DEFAULT_ERROR_MESSAGE, string(body)))
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, []*errors.FieldError{errors.NewFieldError("statusCode", "Auth request failed.")})
 	}
 
 	tokenResponseDTO := integration.NewGoogleOAuthTokenResponseDTO()
 	err = json.NewDecoder(res.Body).Decode(tokenResponseDTO)
 
 	if err != nil {
-		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("response", "Auth request failed.")})
+		logger.Error(fmt.Sprintf("%s: %s", DEFAULT_ERROR_MESSAGE, err.Error()))
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, []*errors.FieldError{errors.NewFieldError("response", "Auth request failed.")})
 	}
 
 	tokenValidationError := service.validateTokenResponseDTO(tokenResponseDTO)
@@ -78,8 +79,8 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 	err = service.saveToken(tokenResponseDTO)
 
 	if err != nil {
-		logger.Error(fmt.Sprintf("%s: %s", defaultErrorMessage, err.Error()))
-		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("token", "Error while saving your credentials.")})
+		logger.Error(fmt.Sprintf("%s: %s", DEFAULT_ERROR_MESSAGE, err.Error()))
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, []*errors.FieldError{errors.NewFieldError("token", "Error while saving your credentials.")})
 	}
 
 	return nil
@@ -95,7 +96,7 @@ func (service *GoogleAuthService) validateTokenResponseDTO(tokenResponseDTO *int
 	}
 
 	if len(dataValidationErrors) > 0 {
-		return errors.NewError("Error while authenticating your google account.", dataValidationErrors)
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, dataValidationErrors)
 	}
 
 	return nil
@@ -130,7 +131,7 @@ func (*GoogleAuthService) validateCodeAndState(code, state string) *errors.Error
 	}
 
 	if len(dataValidationErrors) > 0 {
-		return errors.NewError("Invalid request data.", dataValidationErrors)
+		return errors.NewError(DEFAULT_ERROR_MESSAGE, dataValidationErrors)
 	}
 
 	return nil

--- a/internal/api/service/google_auth_service.go
+++ b/internal/api/service/google_auth_service.go
@@ -39,7 +39,7 @@ func (service *GoogleAuthService) ExchangeCodeForToken(code, state string) *erro
 	}
 
 	decryptedState, _ := common.DecryptAES(state)
-	defaultErrorMessage := "Error while authenticating your Google account."
+	defaultErrorMessage := "Error while authenticating your Google account. Please try again."
 
 	if common.GetEnv("GOOGLE_CLOUD_AUTH_STATE_SECRET_KEY") != decryptedState {
 		return errors.NewError(defaultErrorMessage, []*errors.FieldError{errors.NewFieldError("state", "Invalid origin state.")})


### PR DESCRIPTION
### Impacto

#### Por que esta implementação é necessária?

Com o intuito de lidar com [permissões granulares das contas google](https://developers.google.com/identity/protocols/oauth2/resources/granular-permissions?hl=pt-br), ou seja, quando o usuário autoriza menos escopos dos que o que cadastramos como necessários para integrar com as APIs do google para as features que usaremos no projeto, faz-se necessário validar qual escopo o usuário concedeu quando nós obtemos o token de autorização do usuário. 

#### O que foi feito

1. Validamos as informações de escopo do token criado após autorização do usuário no nosso fluxo de trocar o código de autorização pelo token. Desta forma, caso o usuário tenha autorizado a aplicação sem o escopo da agenda ou os escopos de identificação para sabermos quem é o user (email, profile, openIdConnect scope), não salvamos o token, e devolvemos uma mensagem ao usuário dizendo que todas as permissões precisam ser devidamente autorizadas, nós também não salvamos o token com escopos incompletos e esperamos a próxima autorização para que seja validado novamente e salvo apenas nos casos em que todos os escopos são fornecidos corretamente para o HabitsTodo.

2. Modificação nas respostas API do método `GoogleAuthService.ExchangeCodeForToken`. As mensagens estavam muito técnicas. Não faz sentido elas serem assim. Pois é o usuário que receberá diretamente estas mensagens de erro. Então faz sentido dar uma orientação mais clara do que fazer mediante os erros. 

### Link da tarefa

[Notion](https://www.notion.so/HabitsTodo-Backend-Implementar-valida-o-do-escopo-autorizado-pelo-usuario-na-conta-google-179059f0e43e809c8a60ff2aedfb5a92?pvs=4)

### Cenários testados

#### Usuário não nos dá a permissão de agenda, mas autoriza nosso aplicativo (deve dar erro e devolver ao usuário):

1 - Execução do cenário:

![cenario_erro](https://github.com/user-attachments/assets/89b9b613-42e9-46d1-b1a5-3b81192882bc)

2 - Resposta exibida na URL de redirecionamento:

![api-response-url-redirecionamento](https://github.com/user-attachments/assets/b35b4e8f-fe3a-4faf-a1df-a7a55fe0b1e2)

#### Usuário nos dá a permissão corretamente (não devolve erro e salva o token):

![cenario_sucesso](https://github.com/user-attachments/assets/3a5b1583-4d4a-4117-a3f0-ec67e1215843)
